### PR TITLE
Fix of tree-select component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4504,7 +4504,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4919,7 +4920,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4975,6 +4977,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5018,12 +5021,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/projects/asi-ngtools/src/lib/asi-ngtools-base.module.ts
+++ b/projects/asi-ngtools/src/lib/asi-ngtools-base.module.ts
@@ -5,11 +5,11 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import {
-  AsiComponentTemplateOptionDef, AsiComponentTemplateEmptyDef, AsiComponentTemplateTagDef,
-  AsiComponentTemplateCellDef, AsiComponentTemplateSelectedDef, AsiComponentTemplateColumnDef,
-  AsiComponentTemplateTabHeaderDef, AsiComponentTemplateTableHeaderDef,
-  AsiComponentTemplateTreeNodeDef, AsiComponentTemplateTreeLeafDef,
-  AsiComponentTemplate, AsiComponentTemplateCollapseHeaderDef, AsiComponentTemplateNavHeaderDef
+  AsiComponentTemplateOptionDef, AsiComponentTemplateEmptyDef, AsiComponentTemplateClearDef,
+  AsiComponentTemplateTagDef, AsiComponentTemplateCellDef, AsiComponentTemplateSelectedDef,
+  AsiComponentTemplateColumnDef, AsiComponentTemplateTabHeaderDef, AsiComponentTemplateTableHeaderDef,
+  AsiComponentTemplateTreeNodeDef, AsiComponentTemplateTreeLeafDef, AsiComponentTemplate,
+  AsiComponentTemplateCollapseHeaderDef, AsiComponentTemplateNavHeaderDef
 } from './components/common/asi-component-template';
 
 export * from './components/common/default-control-value-accessor';
@@ -21,6 +21,7 @@ export * from './components/common/asi-component-template';
     AsiComponentTemplateTableHeaderDef,
     AsiComponentTemplateOptionDef,
     AsiComponentTemplateEmptyDef,
+    AsiComponentTemplateClearDef,
     AsiComponentTemplateSelectedDef,
     AsiComponentTemplateColumnDef,
     AsiComponentTemplateCellDef,
@@ -44,6 +45,7 @@ export * from './components/common/asi-component-template';
     AsiComponentTemplateTableHeaderDef,
     AsiComponentTemplateOptionDef,
     AsiComponentTemplateEmptyDef,
+    AsiComponentTemplateClearDef,
     AsiComponentTemplateSelectedDef,
     AsiComponentTemplateTagDef,
     AsiComponentTemplateColumnDef,

--- a/projects/asi-ngtools/src/lib/components/asi-input/asi-input.component.html
+++ b/projects/asi-ngtools/src/lib/components/asi-input/asi-input.component.html
@@ -1,9 +1,8 @@
 <label class="input-label" *ngIf="label != null">{{label | translate}}</label>
-<input #asiInput 
-[attr.id]="id"
-[attr.name]="name"
-[attr.type]="type" 
-[attr.disabled]="disabled ? '' : null" 
-class="asi-focus-error" 
-[placeholder]="placeholder" 
-[formControl]="inputControl" />
+<input #asiInput class="asi-focus-error"
+       [attr.id]="id"
+       [attr.name]="name"
+       [attr.type]="type"
+       [attr.disabled]="disabled ? '' : null"
+       [attr.placeholder]="placeholder"
+       [formControl]="inputControl"/>

--- a/projects/asi-ngtools/src/lib/components/asi-tree-select/asi-tree-select.component.html
+++ b/projects/asi-ngtools/src/lib/components/asi-tree-select/asi-tree-select.component.html
@@ -1,16 +1,16 @@
 <label class="input-label" *ngIf="label">{{label | translate}}</label>
 
 <div class="select" [class.disabled]="disabled">
-  <div class="header asi-focus-error">
+  <div class="header asi-focus-error" (click)="toggleDropdown()" #selectHeader>
     <asi-input [placeholder]="placeholder" [formControl]="formControl"
-               [disabled]="disabled" [id]="id" [name]="name" (onValueChange)="onFilter($event)"
-               (click)="toggleDropdown()"></asi-input>
+               [disabled]="disabled" [id]="id" [name]="name" (onValueChange)="onFilter($event)"></asi-input>
     <asi-fa-icon [icon]="(dropdownOpened) ? 'fa fa-chevron-up' : 'fa fa-chevron-down'"
                  [disabled]="disabled"></asi-fa-icon>
   </div>
 
   <div class="options">
-    <asi-dropdown [calculWidth]="true" [open]="dropdownOpened" (onClose)="onDropdownClosed()">
+    <asi-dropdown [relativeTo]="selectHeaderContainer" [calculWidth]="true" [open]="dropdownOpened"
+                  (onClose)="onDropdownClosed()">
       <div class="drop-down-tree-select">
         <div class="drop-down-panel">
           <asi-tree-view [data]="data" [isLeaf]="isLeaf" [nodeName]="childrenField"

--- a/projects/asi-ngtools/src/lib/components/asi-tree-select/asi-tree-select.component.html
+++ b/projects/asi-ngtools/src/lib/components/asi-tree-select/asi-tree-select.component.html
@@ -1,11 +1,14 @@
 <label class="input-label" *ngIf="label">{{label | translate}}</label>
 
 <div class="select" [class.disabled]="disabled">
-  <div class="header asi-focus-error" (click)="toggleDropdown()" #selectHeader>
+  <div class="header asi-focus-error" #selectHeader>
     <asi-input [placeholder]="placeholder" [formControl]="formControl"
-               [disabled]="disabled" [id]="id" [name]="name" (onValueChange)="onFilter($event)"></asi-input>
+               [disabled]="disabled" [id]="id" [name]="name" (onValueChange)="onFilter($event)"
+               (click)="toggleDropdown()"></asi-input>
+    <asi-fa-icon *ngIf="displayClearButton()" (click)="clear()" icon="fas fa-times"
+                 class="smaller"></asi-fa-icon>
     <asi-fa-icon [icon]="(dropdownOpened) ? 'fa fa-chevron-up' : 'fa fa-chevron-down'"
-                 [disabled]="disabled"></asi-fa-icon>
+                 [disabled]="disabled" (click)="toggleDropdown()"></asi-fa-icon>
   </div>
 
   <div class="options">
@@ -13,6 +16,10 @@
                   (onClose)="onDropdownClosed()">
       <div class="drop-down-tree-select">
         <div class="drop-down-panel">
+          <div *ngIf="clearDef" (click)="clear()" class="clear-value-item">
+            <ng-template [ngTemplateOutlet]="clearDef.template"></ng-template>
+          </div>
+
           <asi-tree-view [data]="data" [isLeaf]="isLeaf" [nodeName]="childrenField"
                          (onNodeSelected)="onNodeSelected($event)"
                          iconOpen="far fa-plus-square" iconClose="far fa-minus-square">

--- a/projects/asi-ngtools/src/lib/components/asi-tree-select/asi-tree-select.component.ts
+++ b/projects/asi-ngtools/src/lib/components/asi-tree-select/asi-tree-select.component.ts
@@ -1,12 +1,11 @@
-import { Component, Input, Output, EventEmitter, ViewChild, OnInit, Renderer2, ElementRef, forwardRef, ContentChild } from '@angular/core';
+import { Component, Input, ViewChild, OnInit, Renderer2, ElementRef, forwardRef, ContentChild } from '@angular/core';
 import { FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
 
+import { AsiComponentTemplateTreeLeafDef, AsiComponentTemplateTreeNodeDef } from '../common/asi-component-template';
 import { AsiTreeViewComponent } from '../asi-tree-view/asi-tree-view.component';
 import { AsiTreeViewNodeComponent } from '../asi-tree-view/node/asi-tree-view-node.component';
 import { DefaultControlValueAccessor } from '../common/default-control-value-accessor';
-
 import * as nh from '../../native-helper';
-import { AsiComponentTemplateTreeLeafDef, AsiComponentTemplateTreeNodeDef } from '../common/asi-component-template';
 
 @Component({
   selector: 'asi-tree-select',
@@ -52,9 +51,7 @@ export class AsiTreeSelectComponent extends DefaultControlValueAccessor implemen
   /** Functions used to decide if an item should be displayed when a filter is applied (returns a boolean) */
   @Input() filter: (item: any, filter: string) => boolean;
 
-  /** Event when the selected item changes (returns the new item selected) */
-  @Output() onSelectionChange = new EventEmitter<any>();
-
+  @ViewChild('selectHeader') selectHeaderContainer: ElementRef;
   @ViewChild(AsiTreeViewComponent) asiTreeView: AsiTreeViewComponent;
 
   @ContentChild(AsiComponentTemplateTreeNodeDef) nodeDef: AsiComponentTemplateTreeNodeDef;

--- a/projects/asi-ngtools/src/lib/components/asi-tree-select/asi-tree-select.component.ts
+++ b/projects/asi-ngtools/src/lib/components/asi-tree-select/asi-tree-select.component.ts
@@ -1,7 +1,11 @@
 import { Component, Input, ViewChild, OnInit, Renderer2, ElementRef, forwardRef, ContentChild } from '@angular/core';
 import { FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { AsiComponentTemplateTreeLeafDef, AsiComponentTemplateTreeNodeDef } from '../common/asi-component-template';
+import {
+  AsiComponentTemplateTreeLeafDef,
+  AsiComponentTemplateTreeNodeDef,
+  AsiComponentTemplateClearDef
+} from '../common/asi-component-template';
 import { AsiTreeViewComponent } from '../asi-tree-view/asi-tree-view.component';
 import { AsiTreeViewNodeComponent } from '../asi-tree-view/node/asi-tree-view-node.component';
 import { DefaultControlValueAccessor } from '../common/default-control-value-accessor';
@@ -51,9 +55,13 @@ export class AsiTreeSelectComponent extends DefaultControlValueAccessor implemen
   /** Functions used to decide if an item should be displayed when a filter is applied (returns a boolean) */
   @Input() filter: (item: any, filter: string) => boolean;
 
+  /** Display a clear button */
+  @Input() clearButton = false;
+
   @ViewChild('selectHeader') selectHeaderContainer: ElementRef;
   @ViewChild(AsiTreeViewComponent) asiTreeView: AsiTreeViewComponent;
 
+  @ContentChild(AsiComponentTemplateClearDef) clearDef: AsiComponentTemplateClearDef;
   @ContentChild(AsiComponentTemplateTreeNodeDef) nodeDef: AsiComponentTemplateTreeNodeDef;
   @ContentChild(AsiComponentTemplateTreeLeafDef) leafDef: AsiComponentTemplateTreeLeafDef;
 
@@ -109,8 +117,14 @@ export class AsiTreeSelectComponent extends DefaultControlValueAccessor implemen
     this.dropdownOpened = false;
   }
 
-  setDisabledState(disabled: boolean): void {
-    this.disabled = disabled;
+  clear() {
+    this.dropdownOpened = false;
+    this.value = null;
+    this.formControl.reset();
+  }
+
+  displayClearButton(): boolean {
+    return this.clearButton && this.value;
   }
 
   // override DefaultControlValueAccessor#writeValue
@@ -118,6 +132,8 @@ export class AsiTreeSelectComponent extends DefaultControlValueAccessor implemen
     this._value = value;
     if (this.value && this.value[this.labelField]) {
       this.formControl.setValue(this.value[this.labelField], { emitEvent: false });
+    } else {
+      this.formControl.reset();
     }
   }
 

--- a/projects/asi-ngtools/src/lib/components/common/asi-component-template.ts
+++ b/projects/asi-ngtools/src/lib/components/common/asi-component-template.ts
@@ -1,7 +1,7 @@
 import { Directive, TemplateRef, Component } from '@angular/core';
 
 @Component({
-  selector: 'asi-option, asi-tag, asi-selected, asi-empty, asi-header, asi-cell, asi-tree-node, asi-tree-leaf',
+  selector: 'asi-option, asi-tag, asi-selected, asi-empty, asi-header, asi-cell, asi-tree-node, asi-tree-leaf, asi-clear',
   template: '<ng-content></ng-content>'
 })
 export class AsiComponentTemplate {
@@ -38,6 +38,14 @@ export class AsiComponentTemplateSelectedDef {
   selector: '[asiEmptyDef]',
 })
 export class AsiComponentTemplateEmptyDef {
+  constructor(public template: TemplateRef<any>) {
+  }
+}
+
+@Directive({
+  selector: '[asiClearDef]',
+})
+export class AsiComponentTemplateClearDef {
   constructor(public template: TemplateRef<any>) {
   }
 }

--- a/projects/asi-ngtools/src/lib/styles/less/asi-tree-select.less
+++ b/projects/asi-ngtools/src/lib/styles/less/asi-tree-select.less
@@ -5,6 +5,7 @@ asi-tree-select, .asi-tree-select {
     display: flex;
     flex: 1 0 auto;
     flex-direction: column;
+    background-color: @asi-select-header-background-color;
 
     &.disabled {
       background-color: @asi-disabled-background-color;
@@ -68,9 +69,13 @@ asi-tree-select, .asi-tree-select {
         display: flex;
         flex-direction: row;
         flex: 1 0 auto;
-        padding: 5px 5px 5px 10px;
         margin-bottom: 5px;
+        padding: 0;
         border: none;
+
+        .tree-node-content {
+          padding: 5px 5px 5px 10px;;
+        }
 
         &.found {
           border: none;

--- a/projects/asi-ngtools/src/lib/styles/less/asi-tree-select.less
+++ b/projects/asi-ngtools/src/lib/styles/less/asi-tree-select.less
@@ -42,6 +42,12 @@ asi-tree-select, .asi-tree-select {
           }
         }
       }
+
+      asi-fa-icon, .asi-fa-icon {
+        &.smaller button {
+          font-size: 0.7rem;
+        }
+      }
     }
   }
 }
@@ -60,6 +66,20 @@ asi-tree-select, .asi-tree-select {
     padding-bottom: 1px;
     box-sizing: border-box;
 
+    div.clear-value-item {
+      margin: 5px 5px 0 5px;
+      padding: 5px 5px 5px 10px;
+
+      &.found {
+        border: none;
+      }
+
+      &:hover {
+        box-shadow: @asi-select-hover-left-box-shadow;
+        background-color: #F3F3F3;
+      }
+    }
+
     asi-tree-view-node, .asi-tree-view-node {
       display: flex;
       flex-direction: column;
@@ -74,7 +94,7 @@ asi-tree-select, .asi-tree-select {
         border: none;
 
         .tree-node-content {
-          padding: 5px 5px 5px 10px;;
+          padding: 5px 5px 5px 10px;
         }
 
         &.found {

--- a/src/app/views/showroom/asi-ngtools/components/presentation-asi-tree-select/presentation-asi-tree-select.component.html
+++ b/src/app/views/showroom/asi-ngtools/components/presentation-asi-tree-select/presentation-asi-tree-select.component.html
@@ -58,7 +58,7 @@
 @Input() filter: (item: any, filter: string) => boolean;
 
 /** Event when the selected item changes (returns the new item selected) */
-@Output() onSelectionChange = new EventEmitter<any>();"></asi-code-viewer>
+@Output() onValueChange = new EventEmitter<any>();"></asi-code-viewer>
   </asi-tab>
   <asi-tab label="HTML">
     <asi-code-viewer language="html" fromUrl="assets/demo/asi-tree-select/asi-tree-select.component.html"></asi-code-viewer>

--- a/src/app/views/showroom/asi-ngtools/components/presentation-asi-tree-select/presentation-asi-tree-select.component.html
+++ b/src/app/views/showroom/asi-ngtools/components/presentation-asi-tree-select/presentation-asi-tree-select.component.html
@@ -12,7 +12,9 @@
   <div fxLayout="column">
     <h2 translate="COMMON.demo"></h2>
 
-    <asi-tree-select [data]="items" [filter]="filter" label="Label" placeholder="Placeholder">
+    <asi-tree-select [data]="items" [filter]="filter" [clearButton]="true" label="Label" placeholder="Placeholder">
+      <asi-clear *asiClearDef>None</asi-clear>
+
       <asi-tree-node *asiTreeNodeDef="let node">
         {{node.data.label}}
       </asi-tree-node>
@@ -58,7 +60,10 @@
 @Input() filter: (item: any, filter: string) => boolean;
 
 /** Event when the selected item changes (returns the new item selected) */
-@Output() onValueChange = new EventEmitter<any>();"></asi-code-viewer>
+@Output() onValueChange = new EventEmitter<any>();
+
+/** Display a clear button */
+@Input() clearButton = false;"></asi-code-viewer>
   </asi-tab>
   <asi-tab label="HTML">
     <asi-code-viewer language="html" fromUrl="assets/demo/asi-tree-select/asi-tree-select.component.html"></asi-code-viewer>
@@ -110,8 +115,12 @@
         <td>Function used to decide if an item should be displayed when a filter is applied (returns a boolean)</td>
       </tr>
       <tr>
-        <td>(onSelectionChange)</td>
+        <td>(onValueChange)</td>
         <td>Function used to decide if an item should be displayed when a filter is applied (returns a boolean)</td>
+      </tr>
+      <tr>
+        <td>(clearButton)</td>
+        <td>Display a clear button</td>
       </tr>
       </tbody>
     </table>

--- a/src/app/views/showroom/asi-ngtools/components/presentation-asi-tree-select/presentation-asi-tree-select.component.ts
+++ b/src/app/views/showroom/asi-ngtools/components/presentation-asi-tree-select/presentation-asi-tree-select.component.ts
@@ -9,38 +9,38 @@ export class PresentationAsiTreeSelectComponent {
   items = [
     {
       id: 1,
-      label: 'niveau 1',
+      label: 'parent 1',
       children: [
         {
           id: 2,
-          label: 'niveau 1-1',
+          label: 'parent 1-1',
           children: [
             {
               id: 3,
-              label: 'niveau 1-1-1',
+              label: 'child 1-1-1',
               children: []
             },
             {
               id: 4,
-              label: 'niveau 1-1-2',
+              label: 'child 1-1-2',
               children: []
             }
           ]
         },
         {
           id: 5,
-          label: 'niveau 1-2',
+          label: 'child 1-2',
           children: []
         },
         {
           id: 6,
-          label: 'niveau 1-3',
+          label: 'child 1-3',
           children: []
         }
       ]
     }, {
       id: 7,
-      label: 'niveau 2',
+      label: 'child 2',
       children: []
     }
   ];

--- a/src/app/views/showroom/asi-ngtools/full-form/full-form.component.ts
+++ b/src/app/views/showroom/asi-ngtools/full-form/full-form.component.ts
@@ -59,38 +59,38 @@ export class FullFormComponent {
   items = [
     {
       id: 1,
-      label: 'niveau 1',
+      label: 'parent 1',
       children: [
         {
           id: 2,
-          label: 'niveau 1-1',
+          label: 'parent 1-1',
           children: [
             {
               id: 3,
-              label: 'niveau 1-1-1',
+              label: 'child 1-1-1',
               children: []
             },
             {
               id: 4,
-              label: 'niveau 1-1-2',
+              label: 'child 1-1-2',
               children: []
             }
           ]
         },
         {
           id: 5,
-          label: 'niveau 1-2',
+          label: 'child 1-2',
           children: []
         },
         {
           id: 6,
-          label: 'niveau 1-3',
+          label: 'child 1-3',
           children: []
         }
       ]
     }, {
       id: 7,
-      label: 'niveau 2',
+      label: 'child 2',
       children: []
     }
   ];

--- a/src/assets/demo/asi-tree-select/asi-tree-select.component.html
+++ b/src/assets/demo/asi-tree-select/asi-tree-select.component.html
@@ -1,4 +1,6 @@
-<asi-tree-select [data]="items" [filter]="filter" label="Label" placeholder="Placeholder">
+<asi-tree-select [data]="items" [filter]="filter" [clearButton]="true" label="Label" placeholder="Placeholder">
+  <asi-clear *asiClearDef>None</asi-clear>
+
   <asi-tree-node *asiTreeNodeDef="let node">
     {{node.data.label}}
   </asi-tree-node>

--- a/src/assets/demo/asi-tree-select/asi-tree-select.component.ts
+++ b/src/assets/demo/asi-tree-select/asi-tree-select.component.ts
@@ -4,43 +4,43 @@ import { Component } from '@angular/core';
   selector: 'presentation-asi-tree-select',
   templateUrl: './presentation-asi-tree-select.component.html'
 })
-export class PresentationAsiTreeSelectComponent {
+export class TreeSelectComponent {
 
   items = [
     {
       id: 1,
-      label: 'niveau 1',
+      label: 'parent 1',
       children: [
         {
           id: 2,
-          label: 'niveau 1-1',
+          label: 'parent 1-1',
           children: [
             {
               id: 3,
-              label: 'niveau 1-1-1',
+              label: 'child 1-1-1',
               children: []
             },
             {
               id: 4,
-              label: 'niveau 1-1-2',
+              label: 'child 1-1-2',
               children: []
             }
           ]
         },
         {
           id: 5,
-          label: 'niveau 1-2',
+          label: 'child 1-2',
           children: []
         },
         {
           id: 6,
-          label: 'niveau 1-3',
+          label: 'child 1-3',
           children: []
         }
       ]
     }, {
       id: 7,
-      label: 'niveau 2',
+      label: 'child 2',
       children: []
     }
   ];

--- a/src/assets/demo/full-form/full-form.component.ts
+++ b/src/assets/demo/full-form/full-form.component.ts
@@ -59,38 +59,38 @@ export class FullFormComponent {
   items = [
     {
       id: 1,
-      label: 'niveau 1',
+      label: 'parent 1',
       children: [
         {
           id: 2,
-          label: 'niveau 1-1',
+          label: 'parent 1-1',
           children: [
             {
               id: 3,
-              label: 'niveau 1-1-1',
+              label: 'child 1-1-1',
               children: []
             },
             {
               id: 4,
-              label: 'niveau 1-1-2',
+              label: 'child 1-1-2',
               children: []
             }
           ]
         },
         {
           id: 5,
-          label: 'niveau 1-2',
+          label: 'child 1-2',
           children: []
         },
         {
           id: 6,
-          label: 'niveau 1-3',
+          label: 'child 1-3',
           children: []
         }
       ]
     }, {
       id: 7,
-      label: 'niveau 2',
+      label: 'child 2',
       children: []
     }
   ];


### PR DESCRIPTION
- fix the open/close arrow background to match the input background
- remove duplicated event onSelectionChange (duplicate of onValueChange)
- fix leaves "hitbox" bug (there was a margin around the content where the click had no effect)
- fix the open/close arrow bug (had no effect)
- fix displayed value when field is cleared (displayed the last selected value)
- add a clear button
- add option to add a "clear" item

& fix inputx placeholder bug (displayed "undefined" when given an undefined variable as placeholder)